### PR TITLE
Feat/implement yamahaos

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Current configuration : 18687 bytes
   | ios         | Cisco IOS                     | ✅ 15.2(5c)E    | Optional           |
   | ssg         | JuniperNetworks ScreenOS      | ✅ 6.3.0r21.0   | Not Available      |
   | ssg-ha      | JuniperNetworks ScreenOS (HA) | ✅ 6.3.0r22.0   | Not Available      |
+  | yamaha      | YAMAHA RT OS                  | ✅ Rev.8.03.94  | Optional           |
 
 ## Development
 

--- a/internal/application/usecase.go
+++ b/internal/application/usecase.go
@@ -7,6 +7,7 @@ import (
 	iosUsecase "telee/internal/application/usecases/ios"
 	ironwareUsecase "telee/internal/application/usecases/ironware"
 	screenosUsecase "telee/internal/application/usecases/screenos"
+	yamahaosUsecase "telee/internal/application/usecases/yamahaos"
 	"telee/internal/config"
 	"telee/internal/infrastructure"
 )
@@ -90,5 +91,13 @@ func (u *Usecase) InvokeASASoftwareHAUsecase() *asasoftwareUsecase.Usecase {
 		Config:     u.Config,
 		Repository: u.Repository,
 		HAMode:     true,
+	}
+}
+
+// InvokeYamahaOSUsecase returns YamahaOSUsecase struct
+func (u *Usecase) InvokeYamahaOSUsecase() *yamahaosUsecase.Usecase {
+	return &yamahaosUsecase.Usecase{
+		Config:     u.Config,
+		Repository: u.Repository,
 	}
 }

--- a/internal/application/usecases/yamahaos/usecase.go
+++ b/internal/application/usecases/yamahaos/usecase.go
@@ -1,0 +1,61 @@
+package usecase
+
+import (
+	"telee/internal/config"
+	"telee/internal/infrastructure"
+
+	x "github.com/google/goexpect"
+)
+
+// Usecase struct
+type Usecase struct {
+	Config     *config.Config
+	Repository *infrastructure.Repository
+}
+
+// Fetch returns stdout from telnet session
+func (u *Usecase) Fetch() (string, error) {
+	var expectation []x.Batcher
+
+	if u.Config.EnableMode {
+		expectation = u.buildPrivilegedRequest()
+	} else {
+		expectation = u.buildUserModeRequest()
+	}
+
+	data, err := u.Repository.InvokeServerRepository().Fetch(&expectation)
+	if err != nil {
+		return "", err
+	}
+	return data, nil
+}
+
+// [platform: yamaha] buildRequest returns the expectation
+func (u *Usecase) buildUserModeRequest() []x.Batcher {
+	return []x.Batcher{
+		&x.BExp{R: "Password:"},
+		&x.BSnd{S: u.Config.Password + "\n"},
+		&x.BExp{R: u.Config.Hostname + ">"},
+		&x.BSnd{S: "console lines infinity\n"},
+		&x.BExp{R: u.Config.Hostname + ">"},
+		&x.BSnd{S: u.Config.Command + "\n"},
+		&x.BExp{R: u.Config.Hostname + ">"},
+	}
+}
+
+// [platform: yamaha] buildPrivilegedRequest returns the expectation
+func (u *Usecase) buildPrivilegedRequest() []x.Batcher {
+	return []x.Batcher{
+		&x.BExp{R: "Password:"},
+		&x.BSnd{S: u.Config.Password + "\n"},
+		&x.BExp{R: u.Config.Hostname + ">"},
+		&x.BSnd{S: "administrator\n"},
+		&x.BExp{R: "Password:"},
+		&x.BSnd{S: u.Config.PrivPassword + "\n"},
+		&x.BExp{R: u.Config.Hostname + "#"},
+		&x.BSnd{S: "console lines infinity\n"},
+		&x.BExp{R: u.Config.Hostname + "#"},
+		&x.BSnd{S: u.Config.Command + "\n"},
+		&x.BExp{R: u.Config.Hostname + "#"},
+	}
+}

--- a/internal/domain/cli.go
+++ b/internal/domain/cli.go
@@ -10,6 +10,7 @@ const (
 	ASASoftwareHAPlatformName string = "asa-ha"
 	ScreenOSPlatformName      string = "ssg"
 	ScreenOSHAPlatformName    string = "ssg-ha"
+	YamahaOSPlatformName      string = "yamaha"
 )
 
 // Used for config validation
@@ -30,5 +31,6 @@ var (
 		ASASoftwareHAPlatformName,
 		ScreenOSPlatformName,
 		ScreenOSHAPlatformName,
+		YamahaOSPlatformName,
 	}
 )

--- a/internal/framework/exec.go
+++ b/internal/framework/exec.go
@@ -53,6 +53,9 @@ func (e *Exec) Run() {
 	if e.Config.ExecPlatform == domain.ASASoftwareHAPlatformName {
 		data, err = e.Usecase.InvokeASASoftwareHAUsecase().Fetch()
 	}
+	if e.Config.ExecPlatform == domain.YamahaOSPlatformName {
+		data, err = e.Usecase.InvokeYamahaOSUsecase().Fetch()
+	}
 
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
- UserMode

```console
$ telee -H lab-rtx1100-02f99-01 -C "show status boot" -t 30 -x yamaha
show status boot 
RTX1100 Rev.8.03.94 (Thu Dec  5 19:06:16 2013)
Restart by cold start command
lab-rtx1100-02f99-01> 
```

- EnableMode (Called AdministratorMode in YAMAHA-RT)

```console
$ telee -H lab-rtx1100-02f99-01 -C "show environment" -t 30 -x yamaha -e
show environment 
RTX1100 BootROM Rev.6.02
RTX1100 Rev.8.03.94 (Thu Dec  5 19:06:16 2013)
  main:  RTX1100 ver=e0 serial=N1A041802 MAC-Address=00:a0:de:32:58:7b MAC-Addr
ess=00:a0:de:32:58:7c MAC-Address=00:a0:de:32:58:7d
CPU:   3%(5sec)   3%(1min)   3%(5min)    Memory: 32% used
Firmware: exec0  Config. file: config0
Default firmware: exec0  Default config. file: config0
Boot time: 1980/01/01 09:18:14 +09:00
Current time: 1980/01/01 10:02:57 +09:00
Elapsed time from boot: 0days 00:44:43
Security Class: 1, FORGET: ON, TELNET: OFF
lab-rtx1100-02f99-01# 
```
