### PR TITLE
Support SSH for IOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,17 +208,33 @@ Current configuration : 18687 bytes
 - telee works for several operating systems. These are called exec-platform.
 - The following table shows each exec-platform was verified on which OS version.
 
-  | Name (`-x`)     | Description                   | Verified On     | Enable Mode (`-e`) |
-  | :-------------- | :---------------------------- | :-------------- | ------------------ |
-  | aireos          | Cisco AireOS                  | ✅ 8.5.120.0    | Optional           |
-  | allied          | AlliedTelesis AlliedWare      | ✅ 1.6.14B02    | Not Available      |
-  | asa             | Cisco ASA Software            | ✅ 9.0(4)       | **REQUIRED**       |
-  | asa (--ha-mode) | Cisco ASA Software (HA)       | ✅ 9.10(1)      | **REQUIRED**       |
-  | foundry         | Brocade IronWare              | ✅ 07.2.02aT7e1 | Optional           |
-  | ios             | Cisco IOS                     | ✅ 15.2(5c)E    | Optional           |
-  | ssg             | JuniperNetworks ScreenOS      | ✅ 6.3.0r21.0   | Not Available      |
-  | ssg (--ha-mode) | JuniperNetworks ScreenOS (HA) | ✅ 6.3.0r22.0   | Not Available      |
-  | yamaha          | YAMAHA RT OS                  | ✅ Rev.8.03.94  | Optional           |
+### Summary
+
+| Name (`-x`)     | Description                   | Enable Mode (`-e`) |
+| :-------------- | :---------------------------- | ------------------ |
+| aireos          | Cisco AireOS                  | Optional           |
+| allied          | AlliedTelesis AlliedWare      | Not Available      |
+| asa             | Cisco ASA Software            | **REQUIRED**       |
+| asa (--ha-mode) | Cisco ASA Software (HA)       | **REQUIRED**       |
+| foundry         | Brocade IronWare              | Optional           |
+| ios             | Cisco IOS                     | Optional           |
+| ssg             | JuniperNetworks ScreenOS      | Not Available      |
+| ssg (--ha-mode) | JuniperNetworks ScreenOS (HA) | Not Available      |
+| yamaha          | YAMAHA RT OS                  | Optional           |
+
+### Verified On
+
+| Name (`-x`)     | Telnet          | SSH (--secure)  |
+| :-------------- | :-------------- | :-------------- |
+| aireos          | ✅ 8.5.120.0    | ⚠ Not verified  |
+| allied          | ✅ 1.6.14B02    | ✅ Not verified |
+| asa             | ✅ 9.0(4)       | ⚠ Not verified  |
+| asa (--ha-mode) | ✅ 9.10(1)      | ⚠ Not verified  |
+| foundry         | ✅ 07.2.02aT7e1 | ⚠ Not verified  |
+| ios             | ✅ 15.2(5c)E    | ✅ 15.2(5c)E    |
+| ssg             | ✅ 6.3.0r21.0   | ⚠ Not verified  |
+| ssg (--ha-mode) | ✅ 6.3.0r22.0   | ⚠ Not verified  |
+| yamaha          | ✅ Rev.8.03.94  | ⚠ Not verified  |
 
 ## Development
 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -16,6 +16,7 @@ func registerFlags() []cli.Flag {
 	flags = append(flags, registerExecPlatformFlag()...)
 	flags = append(flags, registerEnableModeFlag()...)
 	flags = append(flags, registerHAModeFlag()...)
+	flags = append(flags, registerSecureModeFlag()...)
 	flags = append(flags, registerUsernameFlag()...)
 	flags = append(flags, registerPasswordFlag()...)
 	flags = append(flags, registerPrivPasswordFlag()...)
@@ -104,6 +105,18 @@ func registerHAModeFlag() []cli.Flag {
 			Usage:   domain.HAModeFlagUsage,
 			Aliases: domain.HAModeFlagAliases,
 			Value:   domain.HAModeFlagDefaultValue,
+		},
+	}
+}
+
+// Declare secure-mode flag
+func registerSecureModeFlag() []cli.Flag {
+	return []cli.Flag{
+		&cli.BoolFlag{
+			Name:    domain.SecureModeFlagName,
+			Usage:   domain.SecureModeFlagUsage,
+			Aliases: domain.SecureModeFlagAliases,
+			Value:   domain.SecureModeFlagDefaultValue,
 		},
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/urfave/cli/v2 v2.2.0
 	github.com/ziutek/telnet v0.0.0-20180329124119-c3b780dc415b
+	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	ExecPlatform string
 	EnableMode   bool
 	HAMode       bool
+	SecureMode   bool
 	Command      string
 	Username     string
 	Password     string
@@ -39,6 +40,7 @@ func New(ctx *cli.Context) Config {
 		ExecPlatform: ctx.String(domain.ExecPlatformFlagName),
 		EnableMode:   ctx.Bool(domain.EnableModeFlagName),
 		HAMode:       ctx.Bool(domain.HAModeFlagName),
+		SecureMode:   ctx.Bool(domain.SecureModeFlagName),
 		Username:     ctx.String(domain.UsernameFlagName),
 		Password:     ctx.String(domain.PasswordFlagName),
 		PrivPassword: ctx.String(domain.PrivPasswordFlagName),
@@ -58,6 +60,9 @@ func New(ctx *cli.Context) Config {
 }
 
 func checkArguments(cfg *Config) error {
+	if cfg.Port == 0 {
+		completePortNumber(cfg)
+	}
 	if cfg.Username == domain.UsernameFlagDefaultValue {
 		return errors.ErrMissingUsername
 	}
@@ -90,6 +95,15 @@ func checkArguments(cfg *Config) error {
 	}
 
 	return nil
+}
+
+func completePortNumber(cfg *Config) bool {
+	if cfg.SecureMode {
+		cfg.Port = domain.SSHPort
+	} else {
+		cfg.Port = domain.TelnetPort
+	}
+	return true
 }
 
 func isExpandableTermLength(mode bool, platform string) bool {

--- a/internal/domain/flags.go
+++ b/internal/domain/flags.go
@@ -9,6 +9,7 @@ const (
 	ExecPlatformFlagName string = "exec-platform"
 	EnableModeFlagName   string = "enable-mode"
 	HAModeFlagName       string = "ha-mode"
+	SecureModeFlagName   string = "secure-mode"
 	UsernameFlagName     string = "username"
 	PasswordFlagName     string = "password"
 	PrivPasswordFlagName string = "priv-password"
@@ -23,6 +24,7 @@ const (
 	ExecPlatformFlagUsage string = "Set exec-platform. Refer to README.md what to be set."
 	EnableModeFlagUsage   string = "Raise to privileged EXEC mode."
 	HAModeFlagUsage       string = "Use high-availability prompt mode."
+	SecureModeFlagUsage   string = "Use ssh mode."
 	UsernameFlagUsage     string = "Set username."
 	PasswordFlagUsage     string = "Set password."
 	PrivPasswordFlagUsage string = "Set password to raise to privileged EXEC mode."
@@ -30,11 +32,12 @@ const (
 
 // Flag values
 const (
-	PortFlagDefaultValue         int    = 23
+	PortFlagDefaultValue         int    = 0
 	TimeoutFlagDefaultValue      int    = 5
 	ExecPlatformFlagDefaultValue string = "ios"
 	EnableModeFlagDefaultValue   bool   = false
 	HAModeFlagDefaultValue       bool   = false
+	SecureModeFlagDefaultValue   bool   = false
 	UsernameFlagDefaultValue     string = "admin"
 	PasswordFlagDefaultValue     string = "cisco"
 	PrivPasswordFlagDefaultValue string = "enable"
@@ -55,6 +58,7 @@ var (
 	ExecPlatformFlagAliases = []string{"x"}
 	EnableModeFlagAliases   = []string{"e", "ena", "enable"}
 	HAModeFlagAliases       = []string{"ha"}
+	SecureModeFlagAliases   = []string{"s", "sec", "secure"}
 	UsernameFlagAliases     = []string{"u"}
 	PasswordFlagAliases     = []string{"p"}
 	PrivPasswordFlagAliases = []string{"pp"}

--- a/internal/domain/protocols.go
+++ b/internal/domain/protocols.go
@@ -1,6 +1,12 @@
 package domain
 
-// Protocols for telnet
+// protocols
 const (
 	ProtocolTCP string = "tcp"
+)
+
+// ports
+const (
+	SSHPort    int = 22
+	TelnetPort int = 23
 )

--- a/internal/infrastructure/repositories/ios/repository.go
+++ b/internal/infrastructure/repositories/ios/repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"telee/internal/config"
 	"telee/internal/domain"
+	"telee/pkg/ssh"
 	"telee/pkg/telnet"
 	"time"
 
@@ -17,24 +18,43 @@ type Repository struct {
 // Fetch returns stdout from telnet session
 func (r *Repository) Fetch() (string, error) {
 	var expects []x.Batcher
+	var data string
+	var err error
 
-	if r.Config.EnableMode {
+	telnetClient := telnet.New(
+		r.Config.Hostname, r.Config.Port, domain.ProtocolTCP, time.Duration(r.Config.Timeout)*time.Second,
+	)
+	sshClient := ssh.New(
+		r.Config.Hostname, r.Config.Port, domain.ProtocolTCP, time.Duration(r.Config.Timeout)*time.Second,
+	)
+
+	// ssh
+	if r.Config.SecureMode && r.Config.EnableMode {
+		expects = r.buildPrivilegedSecureRequest()
+	}
+	if r.Config.SecureMode && !r.Config.EnableMode {
+		expects = r.buildUserModeSecureRequest()
+	}
+	if !r.Config.SecureMode && r.Config.EnableMode {
 		expects = r.buildPrivilegedRequest()
-	} else {
+	}
+	if !r.Config.SecureMode && !r.Config.EnableMode {
 		expects = r.buildUserModeRequest()
 	}
 
-	client := telnet.New(
-		r.Config.Hostname, r.Config.Port, domain.ProtocolTCP, time.Duration(r.Config.Timeout)*time.Second,
-	)
-	data, err := client.Fetch(&expects)
+	if r.Config.SecureMode {
+		data, err = sshClient.Fetch(&expects, ssh.GenerateClientConfig(r.Config.Username, r.Config.Password))
+	} else {
+		data, err = telnetClient.Fetch(&expects)
+	}
+
 	if err != nil {
 		return "", err
 	}
 	return data, nil
 }
 
-// [platform: ios] buildRequest returns the expects
+// [platform: ios] buildUserModeRequest returns the expects
 func (r *Repository) buildUserModeRequest() []x.Batcher {
 	return []x.Batcher{
 		&x.BExp{R: "Username:"},
@@ -56,6 +76,32 @@ func (r *Repository) buildPrivilegedRequest() []x.Batcher {
 		&x.BSnd{S: r.Config.Username + "\n"},
 		&x.BExp{R: "Password:"},
 		&x.BSnd{S: r.Config.Password + "\n"},
+		&x.BExp{R: r.Config.Hostname + ">"},
+		&x.BSnd{S: "enable\n"},
+		&x.BExp{R: "Password:"},
+		&x.BSnd{S: r.Config.PrivPassword + "\n"},
+		&x.BExp{R: r.Config.Hostname + "#"},
+		&x.BSnd{S: "terminal length 0\n"},
+		&x.BExp{R: r.Config.Hostname + "#"},
+		&x.BSnd{S: r.Config.Command + "\n"},
+		&x.BExp{R: r.Config.Hostname + "#"},
+	}
+}
+
+// [platform: ios] buildUserModeSecureRequest returns the expects
+func (r *Repository) buildUserModeSecureRequest() []x.Batcher {
+	return []x.Batcher{
+		&x.BExp{R: r.Config.Hostname + ">"},
+		&x.BSnd{S: "terminal length 0\n"},
+		&x.BExp{R: r.Config.Hostname + ">"},
+		&x.BSnd{S: r.Config.Command + "\n"},
+		&x.BExp{R: r.Config.Hostname + ">"},
+	}
+}
+
+// [platform: ios] buildPrivilegedSecureRequest returns the expects
+func (r *Repository) buildPrivilegedSecureRequest() []x.Batcher {
+	return []x.Batcher{
 		&x.BExp{R: r.Config.Hostname + ">"},
 		&x.BSnd{S: "enable\n"},
 		&x.BExp{R: "Password:"},

--- a/pkg/ssh/client.go
+++ b/pkg/ssh/client.go
@@ -1,0 +1,76 @@
+package ssh
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	expect "github.com/google/goexpect"
+	x "github.com/google/goexpect"
+	"golang.org/x/crypto/ssh"
+)
+
+const (
+	errSSHSpawnFailed = "SSH was failed at spawn(). You can troubleshoot using wireshark.\n"
+	errSSHBatchFailed = "SSH was failed at ExpectBatch(). You can troubleshoot using wireshark.\n"
+)
+
+// SSH struct
+type SSH struct {
+	host     string
+	port     int
+	protocol string
+	timeout  time.Duration
+}
+
+// New returns SSH struct
+func New(host string, port int, protocol string, timeout time.Duration) *SSH {
+	return &SSH{
+		host:     host,
+		port:     port,
+		protocol: protocol,
+		timeout:  timeout,
+	}
+}
+
+// GenerateClientConfig returns client config
+func GenerateClientConfig(username string, password string) *ssh.ClientConfig {
+	return &ssh.ClientConfig{
+		User:            username,
+		Auth:            []ssh.AuthMethod{ssh.Password(password)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), // nolint: gosec
+	}
+}
+
+// Fetch starts the expect process.
+func (c *SSH) Fetch(x *[]x.Batcher, config *ssh.ClientConfig) (string, error) {
+	conn, err := c.dial(config)
+	if err != nil {
+		fmt.Println(errSSHSpawnFailed)
+		return "", err
+	}
+	defer conn.Close() // nolint: errcheck
+
+	expecter, _, err := expect.SpawnSSH(conn, c.timeout)
+	if err != nil {
+		fmt.Println(errSSHSpawnFailed)
+		return "", err
+	}
+	defer expecter.Close() // nolint: errcheck
+
+	stdout, err := expecter.ExpectBatch(*x, c.timeout)
+	if err != nil {
+		fmt.Println(errSSHBatchFailed)
+		return "", err
+	}
+
+	return stdout[len(stdout)-1].Output, nil
+}
+
+func (c *SSH) dial(config *ssh.ClientConfig) (*ssh.Client, error) {
+	conn, err := ssh.Dial(c.protocol, c.host+":"+strconv.Itoa(c.port), config)
+	if err != nil {
+		return nil, err
+	}
+	return conn, nil
+}


### PR DESCRIPTION
## User Mode

```
$ telee --hostname lab-cat29l-02f99-01 -C "show ver" --secure | head -n 10
show ver
Load for five secs: 1%/0%; one minute: 2%; five minutes: 1%
Time source is NTP, 02:14:05.978 JST Fri May 14 2021
Cisco IOS Software, C2960L Software (C2960L-UNIVERSALK9-M), Version 15.2(5c)E, RELEASE SOFTWARE (fc1)
Technical Support: http://www.cisco.com/techsupport
Copyright (c) 1986-2016 by Cisco Systems, Inc.
Compiled Tue 18-Oct-16 23:59 by prod_rel_team

ROM: Bootstrap program is HAYWARDS boot loader
BOOTLDR: C2960L Boot Loader (C2960L-HBOOT-M) Version 15.2(5r)E1, RELEASE SOFTWARE (fc2)
```

## Privileged Mode

```
$ telee --hostname lab-cat29l-02f99-01 -C "show run" --secure --enable | head -n 10
show run
Load for five secs: 1%/0%; one minute: 1%; five minutes: 1%
Time source is NTP, 02:13:45.553 JST Fri May 14 2021

Building configuration...

Current configuration : 18716 bytes
!
! Last configuration change at 01:46:41 JST Fri May 14 2021 by raciadev
!
```