### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -1,5 +1,8 @@
 name: Update Tag on VERSION Change
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/umatare5/telee/security/code-scanning/2](https://github.com/umatare5/telee/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow or the specific job. Since the job pushes tags, it requires `contents: write` permission. The best practice is to set the minimal required permissions at the workflow level unless different jobs require different permissions. In this case, adding the following at the top level (just after the `name:` or `on:` block) is sufficient:

```yaml
permissions:
  contents: write
```

This ensures that the `GITHUB_TOKEN` used by the workflow only has the permissions necessary to push tags, and nothing more. No other permissions (such as `issues`, `pull-requests`, etc.) are needed for this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
