### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Release Application to ghcr.io and Artifacts
 
+permissions:
+  contents: write
+  packages: write
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/umatare5/telee/security/code-scanning/1](https://github.com/umatare5/telee/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file. This can be done at the workflow level (applies to all jobs) or at the job level (applies only to the specified job). The minimal permissions required for a release workflow that pushes to the GitHub Container Registry and uploads release artifacts are typically:

- `contents: write` (to create releases, upload assets, etc.)
- `packages: write` (to push images to ghcr.io)

Add the following block near the top of the workflow file, after the `name:` and before `on:`:

```yaml
permissions:
  contents: write
  packages: write
```

No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
